### PR TITLE
Re-write processed text (CoNLL fmt) as one sentence per line text

### DIFF
--- a/src/main/scala/agfqg/ConllFmt.scala
+++ b/src/main/scala/agfqg/ConllFmt.scala
@@ -67,8 +67,12 @@ object ConllFmt {
         e => throw e,
         iter => {
           val all = iter.toSeq
-          println(s"Found ${all.size} sentences in Conll Formatted file: $fi")
+          System.err.println(s"Found ${all.size} sentences in Conll Formatted file: $fi")
           all.take(10).foreach { x =>
+            x.tokens.map { _.raw }.mkString("\n")
+
+            // TODO: change so it outputs the sentence in a single line !
+
             val s = x.tokens.mkString("\n")
             println(s"\n$s\n")
           }

--- a/src/main/scala/agfqg/ConllFmt.scala
+++ b/src/main/scala/agfqg/ConllFmt.scala
@@ -9,16 +9,6 @@ import scalaz.\/
 
 object ConllFmt {
 
-  def parseConllWord(line: String): ConllWord = {
-    val bits = line.split("\t")
-    ConllWord(
-      raw = bits(1),
-      lemmatized = bits(2),
-      posTag = bits(3),
-      neTag = bits(4)
-    )
-  }
-
   /** Produces an Iterator with **MUTABLE INTERNAL STATE** Not threadsafe!. */
   def reader(fi: File): Err[Iterator[ConllSent]] =
     \/.fromTryCatchNonFatal {
@@ -63,7 +53,27 @@ object ConllFmt {
       }
     }
 
+  def parseConllWord(line: String): ConllWord = {
+    val bits = line.split("\t")
+    ConllWord(
+      raw = bits(1),
+      lemmatized = bits(2),
+      posTag = bits(3),
+      neTag = bits(4)
+    )
+  }
+
+  def writeConllSent(s: ConllSent): String =
+    s.tokens.zipWithIndex.map {
+      case (w, index) => s"$index\t${writeConllWord(w)}"
+    }.mkString("\n") + "\n"
+
+  def writeConllWord(w: ConllWord): String =
+    s"${w.raw}\t${w.lemmatized}\t${w.posTag}\t${w.neTag}"
+
 }
+
+case class ConllSent(tokens: Seq[ConllWord])
 
 case class ConllWord(
     raw: String,
@@ -71,5 +81,3 @@ case class ConllWord(
     posTag: String,
     neTag: String
 )
-
-case class ConllSent(tokens: Seq[ConllWord])

--- a/src/main/scala/agfqg/ConllFmt.scala
+++ b/src/main/scala/agfqg/ConllFmt.scala
@@ -27,18 +27,18 @@ object ConllFmt {
 
         var indexOfLastSentenceEnd: Int = 0
         var indexOfNextSentenceEnd: Int = text.indexOf("\n\n", 0)
-        var active: Boolean = indexOfLastSentenceEnd >= 0
+
+        def isActive() = indexOfLastSentenceEnd >= 0
 
         def advance(): Unit =
-          if (active) {
+          if (isActive()) {
             indexOfLastSentenceEnd = indexOfNextSentenceEnd
             indexOfNextSentenceEnd =
               text.indexOf("\n\n", indexOfLastSentenceEnd + 1)
-            active = indexOfLastSentenceEnd >= 0
           }
 
         override def hasNext: Boolean =
-          active && indexOfLastSentenceEnd >= 0
+          isActive()
 
         override def next(): ConllSent = {
 
@@ -47,8 +47,12 @@ object ConllFmt {
               .slice(indexOfLastSentenceEnd, indexOfNextSentenceEnd)
               .trim
               .split("\n")
-              .filter { _.nonEmpty }
-              .map { parseConllWord }
+              .filter {
+                _.nonEmpty
+              }
+              .map {
+                parseConllWord
+              }
               .toSeq
           )
 
@@ -59,27 +63,6 @@ object ConllFmt {
       }
     }
 
-  def main(args: Array[String]): Unit = {
-    val fi = new File(args.head)
-    ConllFmt
-      .reader(fi)
-      .fold(
-        e => throw e,
-        iter => {
-          val all = iter.toSeq
-          System.err.println(s"Found ${all.size} sentences in Conll Formatted file: $fi")
-          all.take(10).foreach { x =>
-            x.tokens.map { _.raw }.mkString("\n")
-
-            // TODO: change so it outputs the sentence in a single line !
-
-            val s = x.tokens.mkString("\n")
-            println(s"\n$s\n")
-          }
-        }
-      )
-  }
-
 }
 
 case class ConllWord(
@@ -89,9 +72,4 @@ case class ConllWord(
     neTag: String
 )
 
-case class ConllSent(tokens: Seq[ConllWord]) {
-  def text: String =
-    tokens.map { c =>
-      c.raw
-    }.mkString(" ")
-}
+case class ConllSent(tokens: Seq[ConllWord])

--- a/src/main/scala/agfqg/ConllToTextLine.scala
+++ b/src/main/scala/agfqg/ConllToTextLine.scala
@@ -1,33 +1,69 @@
 package agfqg
 
-import java.io.File
+import java.io.{BufferedWriter, File, FileWriter}
+
+import cmd.RunnerHelpers.log
 
 object ConllToTextLine {
 
+  lazy val argHelp: Array[String] => Boolean =
+    args => args.length == 1 && (args.head == "-h" || args.head == "--help")
+
+  val nExpectedArgs = 2
+
   def main(args: Array[String]): Unit = {
 
-    val fi = new File(args.head)
+    if (args.length < nExpectedArgs || argHelp(args)) {
+      log(
+        s"""[HELP] Need $nExpectedArgs arguments:
+           |1st: INPUT processed text, in CoNLL format
+           |2nd: OUTPUT plain text, each line is a complete sentence
+         """.stripMargin
+      )
+      System.exit(1)
+    }
+
+    val processedFi = new File(args.head)
+    log(s"Input, CoNLL-formatted:          $processedFi")
+    val outFi = new File(args(1))
+    log(s"Output, text sentence-per-line:  $outFi")
+    val writingTextTransformer = transformText(outFi) _
+
     ConllFmt
-      .reader(fi)
+      .reader(processedFi)
       .fold(
         e => throw e,
-        iter => {
-          val all = iter.toSeq
-          System.err.println(
-            s"Found ${all.size} sentences in Conll Formatted file: $fi")
-
-          all.take(10).foreach { x =>
-            x.tokens.map {
-              _.raw
-            }.mkString("\n")
-
-            // TODO: change so it outputs the sentence in a single line !
-
-            val s = x.tokens.mkString("\n")
-            println(s"\n$s\n")
-          }
-        }
+        writingTextTransformer
       )
   }
+
+  def transformText(out: File)(iter: Iterator[ConllSent]): Unit = {
+    val w = new BufferedWriter(new FileWriter(out))
+    try {
+      val nSentences = iter.foldLeft(0) {
+        case (n, sentence) =>
+          w.write(asOneLine(sentence))
+          w.newLine()
+          n + 1
+      }
+      w.flush()
+      log(s"Found and wrote $nSentences sentences")
+    } finally {
+      w.close()
+    }
+  }
+
+  def asOneLine(sentence: ConllSent): String =
+    if (sentence.tokens.isEmpty)
+      ""
+    else {
+      val rawWords = sentence.tokens.map { _.raw }
+      val rws =
+        if (rawWords.last == ".")
+          rawWords.slice(0, rawWords.size - 1)
+        else
+          rawWords
+      s"""${rws.mkString(" ")}."""
+    }
 
 }

--- a/src/main/scala/agfqg/ConllToTextLine.scala
+++ b/src/main/scala/agfqg/ConllToTextLine.scala
@@ -1,0 +1,33 @@
+package agfqg
+
+import java.io.File
+
+object ConllToTextLine {
+
+  def main(args: Array[String]): Unit = {
+
+    val fi = new File(args.head)
+    ConllFmt
+      .reader(fi)
+      .fold(
+        e => throw e,
+        iter => {
+          val all = iter.toSeq
+          System.err.println(
+            s"Found ${all.size} sentences in Conll Formatted file: $fi")
+
+          all.take(10).foreach { x =>
+            x.tokens.map {
+              _.raw
+            }.mkString("\n")
+
+            // TODO: change so it outputs the sentence in a single line !
+
+            val s = x.tokens.mkString("\n")
+            println(s"\n$s\n")
+          }
+        }
+      )
+  }
+
+}


### PR DESCRIPTION
This PR adds a new program, `conll-to-text-line`, which transforms a processed text file, in CoNLL format, as a simple, unprocessed, text file. The output format is a sentence on each line. Care is taken during the transformation to merge tokens appropriately (e.g. `["do", "n't"] => "don't"`) and do individual token transformations (e.g. `"-LRB-" => "("`) as well as proper token spacing (e.g. no space between a word and a period).

Currently, the original sentence words are output. It would be relatively easy to have the output tokens be lemmatized instead.