### PR TITLE
Quiz Question Generation as JSON

### DIFF
--- a/project/SharedBuild.scala
+++ b/project/SharedBuild.scala
@@ -14,6 +14,7 @@ object SharedBuild {
   lazy val silencerV   = "0.5"
   lazy val sistaV      = "6.0.1"
   lazy val coreNlpV    = "3.6.0"
+  lazy val raptureV    = "2.0.0-M7"
   lazy val langDtV     = "1.1.1"
 
   // // // // // // // // // //
@@ -32,6 +33,7 @@ object SharedBuild {
    "edu.stanford.nlp" % "stanford-corenlp" % coreNlpV,
    "edu.stanford.nlp" % "stanford-parser"  % coreNlpV,
    "io.malcolmgreaves" %% "cybozu-language-detection" % langDtV,
+   "com.propensive"         %% "rapture"       % raptureV,
     // [BEGIN] PUBLISHED LOCAL
     "io.malcolmgreaves" %% "fp4ml-spark" % fp4mlV,
     // ^^ includes all of below:

--- a/src/main/scala/agfqg/FinalQuizQuestionsJson.scala
+++ b/src/main/scala/agfqg/FinalQuizQuestionsJson.scala
@@ -1,0 +1,38 @@
+package agfqg
+
+import java.io.{BufferedWriter, File, FileWriter}
+
+import cmd.RunnerHelpers.log
+
+object FinalQuizQuestionsJson {
+
+  lazy val argHelp: Array[String] => Boolean =
+    args => args.length == 1 && (args.head == "-h" || args.head == "--help")
+
+  val nExpectedArgs = 3
+
+  def main(args: Array[String]): Unit = {
+
+    if (args.length < nExpectedArgs || argHelp(args)) {
+      log(
+        s"""[HELP] Need $nExpectedArgs arguments:
+           |1st: INPUT selected gaps & generated distractors
+           |2nd: INPUT selected sentences
+           |3rd: OUTPUT JSON formatted, complete, quiz questions
+         """.stripMargin
+      )
+      System.exit(1)
+    }
+
+    val gapDistractorFi = new File(args.head)
+    log(s"Input, selected gaps & generated distractors:     $gapDistractorFi")
+    val selectedSentencesFi = new File(args(1))
+    log(
+      s"Input, selected sentences:                        $selectedSentencesFi")
+    val outFi = new File(args(2))
+    log(s"Output, JSON formatted, complete, quiz questions: $outFi")
+
+    ???
+  }
+
+}

--- a/src/main/scala/agfqg/FinalQuizQuestionsJson.scala
+++ b/src/main/scala/agfqg/FinalQuizQuestionsJson.scala
@@ -6,6 +6,9 @@ import cmd.RunnerHelpers.log
 
 import scala.io.Source
 
+import rapture.json._
+import jsonBackends.jawn._
+
 object FinalQuizQuestionsJson {
 
   lazy val argHelp: Array[String] => Boolean =
@@ -34,8 +37,19 @@ object FinalQuizQuestionsJson {
     log(s"Output, JSON formatted, complete, quiz questions: $outFi")
 
     val qus = quizes(selectSentFi, gapDistractorFi)
+    log(s"Assembled ${qus.size} quizzes.")
+    writeAsJson(outFi, qus)
+  }
 
-    ???
+  def writeAsJson(out: File, quizzes: Iterable[FormattedQuiz]): Unit = {
+    val w = new BufferedWriter(new FileWriter(out))
+    try {
+      val j = Json(quizzes.toIndexedSeq)
+      import formatters.compact._
+      w.write(Json.format(j))
+    } finally {
+      w.close()
+    }
   }
 
   def quizes(selectSentFi: File,

--- a/src/main/scala/agfqg/FinalQuizQuestionsJson.scala
+++ b/src/main/scala/agfqg/FinalQuizQuestionsJson.scala
@@ -72,11 +72,13 @@ object FinalQuizQuestionsJson {
     gapAndDistractors.toList.sortBy { _.index }.map {
       case GapAndDistractors(index, gap, gapCharacterIndicies, distractors) =>
         val selectedSentence = selectedSentences(index)
-        val formattedQuizText =
+        val (formattedQuizText, newEndIndex) =
           gapReplace(selectedSentence.text, gapCharacterIndicies)
         FormattedQuiz(
           index = index,
           questionText = formattedQuizText,
+          replacementStartIndex = gapCharacterIndicies._1,
+          replacementEndIndex = newEndIndex,
           answer = gap,
           distractors = distractors
         )
@@ -122,11 +124,14 @@ object FinalQuizQuestionsJson {
 
   def gapReplace(text: String,
                  gapCharacterIndicies: (Int, Int),
-                 replacement: String = "_____"): String = {
+                 replacement: String = "_____"): (String, Int) = {
     val (start, end) = gapCharacterIndicies
     val upToBeforeStart = text.substring(0, start)
     val atAndAfterEnd = text.substring(end)
-    s"$upToBeforeStart$replacement$atAndAfterEnd"
+    (
+      s"$upToBeforeStart$replacement$atAndAfterEnd",
+      start + replacement.length
+    )
   }
 
 }
@@ -148,6 +153,8 @@ case class GapAndDistractors(
 case class FormattedQuiz(
     index: Int,
     questionText: String,
+    replacementStartIndex: Int,
+    replacementEndIndex: Int,
     answer: String,
     distractors: Seq[String]
 )


### PR DESCRIPTION
This PR adds a new program, `final-quiz-questions-json`, which takes the selected sentences and the gap & distractor output files, combines them, and outputs a JSON list containing fully-formed, multiple-choice, fill-in-the-blank quiz questions.

Each question follows the schema induced from `agfqg.FormattedQuiz`.